### PR TITLE
Adding pandas table functionality

### DIFF
--- a/deephaven_ipywidgets/_version.py
+++ b/deephaven_ipywidgets/_version.py
@@ -4,5 +4,5 @@
 # Copyright (c) Deephaven Data Labs LLC.
 # Distributed under the terms of the Modified BSD License.
 
-version_info = (0, 2, 0, 'dev0')
+version_info = (0, 2, 0)
 __version__ = ".".join(map(str, version_info))

--- a/deephaven_ipywidgets/deephaven.py
+++ b/deephaven_ipywidgets/deephaven.py
@@ -22,7 +22,8 @@ def _str_object_type(obj):
 def _path_for_object(obj):
   """Return the iframe path for the specified object. Inspects the class name to determine."""
   name = _str_object_type(obj)
-  if name == 'deephaven.table.Table':
+
+  if name in ('deephaven.table.Table', 'pandas.core.frame.DataFrame'):
     return 'table'
   if name == 'deephaven.plot.figure.Figure':
     return 'chart'


### PR DESCRIPTION
Fixes #4 
- Added a case to render iframe in the case of pandas dataframe widget
- Tested with local copy of deephaven core, created a simple dataframe and verified that it outputted as expected.
```
from deephaven_server import Server
s = Server(port=8080)
s.start()

from deephaven_ipywidgets import DeephavenWidget
import pandas as pd
data = {"X": [1, 2, 3], "Y": [1, 2, 3]}
df = pd.DataFrame(data)
display(df)
display(DeephavenWidget(df))
```