### PR TITLE
Revert JS version to 0.1.0

### DIFF
--- a/deephaven_ipywidgets/_frontend.py
+++ b/deephaven_ipywidgets/_frontend.py
@@ -9,4 +9,4 @@ Information about the frontend package of the widgets.
 """
 
 module_name = "@deephaven/ipywidgets"
-module_version = "^0.2.0"
+module_version = "^0.1.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deephaven/ipywidgets",
-  "version": "0.2.0",
+  "version": "0.1.0",
   "description": "Deephaven ipython widget library",
   "keywords": [
     "ipywidgets",


### PR DESCRIPTION
- We haven't made any JS plugin changes, we can bump the version when we make changes there.
- Was causing issues when testing with the wheel, as it was trying to pull a version of @deephaven-ipywidgets that hasn't been published.