### PR TITLE
iframe is now loaded when using google colab

### DIFF
--- a/deephaven_ipywidgets/_version.py
+++ b/deephaven_ipywidgets/_version.py
@@ -4,5 +4,5 @@
 # Copyright (c) Deephaven Data Labs LLC.
 # Distributed under the terms of the Modified BSD License.
 
-version_info = (0, 2, 0)
+version_info = (0, 2, 1)
 __version__ = ".".join(map(str, version_info))

--- a/deephaven_ipywidgets/tests/test_table.py
+++ b/deephaven_ipywidgets/tests/test_table.py
@@ -19,5 +19,5 @@ def test_example_creation_blank(MockTableClass):
     mock_table.__class__.__module__ = 'deephaven.table'
     mock_table.__class__.__name__ = 'Table'
     w = DeephavenWidget(mock_table)
-    assert w.server_url == 'http://localhost:9876'
+    assert w.server_url == 'http://localhost:9876/'
     assert str(w.iframe_url).startswith('http://localhost:9876/iframe/table/?name=t_')


### PR DESCRIPTION
Part of fix for #3 

- Added logic to check if the script is being ran in google colab, then replace the server url with proxied url for the specified port if that is the case
- Tested in google colab, created a widget and verified that the iframe appeared 
```
!apt-get install openjdk-11-jdk-headless

import os
from google.colab.output import eval_js
os.environ["JAVA_HOME"] = "/usr/lib/jvm/java-11-openjdk-amd64"

from google.colab import drive
drive.mount('/content/drive')

!pip install --upgrade pip setuptools wheel
!pip install deephaven-core deephaven-server
!pip install '/content/drive/MyDrive/deephaven_ipywidgets-0.2.0-py2.py3-none-any.whl'

import deephaven_server
from deephaven_server import Server
import portpicker
from google.colab.output import eval_js

dh_port = portpicker.pick_unused_port()
s = Server(port=dh_port, jvm_args=["-Xmx4g", "-Dhttp.requireHttp2=false"], dh_args={'http.requireHttp2': False})
s.start()

from google.colab import output
output.enable_custom_widget_manager()

from deephaven import empty_table
t = empty_table(10).update("x=i")

from deephaven_ipywidgets import DeephavenWidget
DeephavenWidget(t)
```