### PR TITLE
Fix iframe in docker container

### DIFF
--- a/deephaven_ipywidgets/deephaven.py
+++ b/deephaven_ipywidgets/deephaven.py
@@ -14,7 +14,7 @@ from traitlets import Unicode, Integer
 from deephaven_server import Server
 from uuid import uuid4
 from ._frontend import module_name, module_version
-
+import os
 
 def _str_object_type(obj):
     """Returns the object type as a string value"""
@@ -63,13 +63,20 @@ class DeephavenWidget(DOMWidget):
         object_id = f"t_{str(uuid4()).replace('-', '_')}"
 
         port = Server.instance.port
+
         server_url = f"http://localhost:{Server.instance.port}/"
+
+        if "DEEPHAVEN_IPY_URL" in os.environ:
+            server_url = os.environ["DEEPHAVEN_IPY_URL"]
 
         try:
             from google.colab.output import eval_js
             server_url = eval_js(f"google.colab.kernel.proxyPort({port})")
         except ImportError:
             pass
+
+        if not server_url.endswith("/"):
+            server_url = f"{server_url}/"
 
         # Generate the iframe_url from the object type
         iframe_url = f"{server_url}iframe/{_path_for_object(deephaven_object)}/?name={object_id}"


### PR DESCRIPTION
Fixes #10 
Verified by creating a docker container:
```
docker run -p 10000:8888 -p 8080:1234 ghcr.io/deephaven/deephaven-kube-demo-worker-jupyter:main
```

Then running the following code in a jupyter notebook in the docker container:
```
from deephaven_server import Server

s = Server(port=1234, jvm_args=["-Xmx10g"])
s.start()

from deephaven_ipywidgets import DeephavenWidget
from deephaven.plot.figure import Figure
from deephaven import empty_table
from deephaven import time_table
from deephaven import ugp

static_table = empty_table(100).update(["X = i", "Y = Math.sin(0.1 * X)"])

import os
os.environ['DEEPHAVEN_IPY_URL'] = "http://localhost:8080/"

static_widget = DeephavenWidget(static_table)
display(static_widget)
```