### PR TITLE
Fixing pypi failure

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,6 +47,9 @@ jobs:
           path: dist/
           if-no-files-found: error
 
+      - name: Remove files not needed for pypi
+        run: rm dist/index.js*
+
       - uses: pypa/gh-action-pypi-publish@release/v1
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
         with:


### PR DESCRIPTION
Extraneous files not needed by the pypi upload step were in the dist folder. This was causing the upload to pypi to fail when a new tag was created.