### PR TITLE
Fixed incorrect js version in python code

### DIFF
--- a/deephaven_ipywidgets/_frontend.py
+++ b/deephaven_ipywidgets/_frontend.py
@@ -9,4 +9,4 @@ Information about the frontend package of the widgets.
 """
 
 module_name = "@deephaven/ipywidgets"
-module_version = "^0.1.0"
+module_version = "0.2.0"


### PR DESCRIPTION
tested with 
```
from deephaven_enterprise.client.session_manager import SessionManager
from deephaven_ipywidgets import DeephavenWidget
connection_info = "info"
session_mgr: SessionManager = SessionManager(connection_info)
session_mgr.password("user", "password")
session = session_mgr.connect_to_persistent_query("Community PQ Python")
qc = session.open_table("tt")
DeephavenWidget(qc)
```