### PR TITLE
fixing enterprise url

### DIFF
--- a/deephaven_ipywidgets/deephaven.py
+++ b/deephaven_ipywidgets/deephaven.py
@@ -16,7 +16,6 @@ from uuid import uuid4
 from ._frontend import module_name, module_version
 import os
 import base64
-import json
 
 
 def _str_object_type(obj):
@@ -89,7 +88,7 @@ class DeephavenWidget(DOMWidget):
             })
 
             port = deephaven_object.session.port
-            server_url = f"https://{deephaven_object.session.host}:{port}"
+            server_url = deephaven_object.session.pqinfo.state.connectionDetails.staticUrl
 
             session.bind_table(object_id, deephaven_object)
         else:

--- a/deephaven_ipywidgets/deephaven.py
+++ b/deephaven_ipywidgets/deephaven.py
@@ -88,7 +88,7 @@ class DeephavenWidget(DOMWidget):
             })
 
             port = deephaven_object.session.port
-            server_url = deephaven_object.session.pqinfo.state.connectionDetails.staticUrl
+            server_url = deephaven_object.session.pqinfo().state.connectionDetails.staticUrl
 
             session.bind_table(object_id, deephaven_object)
         else:


### PR DESCRIPTION
Tested with the following code, both with and without envoy
```
from deephaven_enterprise.client.session_manager import SessionManager
from deephaven_ipywidgets import DeephavenWidget
connection_info = "info"
session_mgr: SessionManager = SessionManager(connection_info)
session_mgr.password("user", "password")
session = session_mgr.connect_to_persistent_query("Test PQ")
qc = session.open_table("tt")
DeephavenWidget(qc)
```