### PR TITLE
Remove iframe when kernel is killed or restarted

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "@babel/preset-env": "^7.5.0",
     "@deephaven/eslint-config": "^0.41.0",
     "@deephaven/prettier-config": "^0.41.0",
-    "@jupyterlab/builder": "^3.6.4",
+    "@jupyterlab/builder": "^4.0.5",
     "@phosphor/application": "^1.6.0",
     "@phosphor/widgets": "^1.6.0",
     "@types/jest": "^26.0.0",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "@babel/preset-env": "^7.5.0",
     "@deephaven/eslint-config": "^0.41.0",
     "@deephaven/prettier-config": "^0.41.0",
-    "@jupyterlab/builder": "^4.0.5",
+    "@jupyterlab/builder": "^3.6.5",
     "@phosphor/application": "^1.6.0",
     "@phosphor/widgets": "^1.6.0",
     "@types/jest": "^26.0.0",

--- a/src/widget.ts
+++ b/src/widget.ts
@@ -131,8 +131,7 @@ export class DeephavenView extends DOMWidgetView {
     }
   };
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  onRestartOrTerminate = (sender: any, args: string) => {
+  onRestartOrTerminate = (sender: unknown, args: string) => {
     if (args === 'restarting' || args === 'terminating') {
       this.onDisconnect(args);
     }


### PR DESCRIPTION
This will remove the iframe in three valid situations:

1. The kernel is restarted
2. The kernel is removed (such as by switching to 'No Kernel')
3. The kernel is killed from the python side

Both 2 and 3 are doable from the python side, as they kill the interpreter, and can be caught via an `atexit` hook. 1 and 2 are doable from the javascript side of the widget by listening to changes to the session status, which is not officially supported for widgets as far as I can tell, but does work. See here for example of these listeners: https://github.com/jupyter-widgets/ipywidgets/blob/main/python/jupyterlab_widgets/src/manager.ts#L427

Only current downside of this approach is it will keep spawning listeners. I'm not sure if there's a good way to prune them or the widget itself completely (as even after the iframe is removed the widget is still around, with the exception of case 3). 

I've tested with the following cells and verified the iframe is removed in all these cases:
```
from deephaven_server import Server
s = Server(port=8080)
s.start()
```

```
from deephaven import time_table
from deephaven_ipywidgets import DeephavenWidget
t = time_table("PT1S").update(["x=i", "y=Math.sin(i)"])
display(DeephavenWidget(t))
```

Also fixes https://github.com/deephaven/deephaven-ipywidgets/issues/23
Checked by copying the cells from the iframe created above