### PR TITLE
ci: trusted publishing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-22.04
+    permissions:
+      id-token: write
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,6 +52,3 @@ jobs:
 
       - uses: pypa/gh-action-pypi-publish@release/v1
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
-        with:
-          user: __token__
-          password: ${{ secrets.DEEPHAVENIPYWIDGETS_PYPI_TOKEN }}


### PR DESCRIPTION
Fixes #39 
We'll need trusted publishing added on pypi and the secret deleted as well