### PR TITLE
feat: Use shared ticket for pydeephaven tables

### DIFF
--- a/deephaven_ipywidgets/deephaven.py
+++ b/deephaven_ipywidgets/deephaven.py
@@ -175,7 +175,7 @@ class DeephavenWidget(DOMWidget):
 
         # Generate the iframe_url from the object type
         iframe_url = (
-            f"http://localhost:4010/{_path_for_object(deephaven_object)}/{param_string}"
+            f"{server_url}iframe/{_path_for_object(deephaven_object)}/{param_string}"
         )
 
         self.set_trait("server_url", server_url)

--- a/deephaven_ipywidgets/deephaven.py
+++ b/deephaven_ipywidgets/deephaven.py
@@ -138,11 +138,15 @@ class DeephavenWidget(DOMWidget):
             server_url, token = _check_session(session, params)
 
         elif _str_object_type(deephaven_object) == "pydeephaven.table.Table":
+            from pydeephaven.session import SharedTicket
             session = deephaven_object.session
 
             server_url, token = _check_session(session, params)
 
-            session.bind_table(object_id, deephaven_object)
+            ticket = SharedTicket(b"h/" + object_id.encode("utf-8"))
+            session.publish_table(ticket, deephaven_object)
+
+            params["shared"] = 'Table'
         else:
             from deephaven_server import Server
             port = Server.instance.port

--- a/deephaven_ipywidgets/deephaven.py
+++ b/deephaven_ipywidgets/deephaven.py
@@ -143,10 +143,12 @@ class DeephavenWidget(DOMWidget):
 
             server_url, token = _check_session(session, params)
 
+            # h/ is the prefix for shared tickets used by the server
             ticket = SharedTicket(b"h/" + object_id.encode("utf-8"))
             session.publish_table(ticket, deephaven_object)
 
-            params["shared"] = 'Table'
+            params["type"] = "Table"
+            params["isShared"] = "true"
         else:
             from deephaven_server import Server
             port = Server.instance.port
@@ -173,7 +175,7 @@ class DeephavenWidget(DOMWidget):
 
         # Generate the iframe_url from the object type
         iframe_url = (
-            f"{server_url}iframe/{_path_for_object(deephaven_object)}/{param_string}"
+            f"http://localhost:4010/{_path_for_object(deephaven_object)}/{param_string}"
         )
 
         self.set_trait("server_url", server_url)


### PR DESCRIPTION
This is one part of #38, specifically using the shared ticked instead of `bind_table` in the case of `pydeephaven` tables

Requires https://github.com/deephaven/web-client-ui/pull/2189

Tested with the following code
```
from deephaven_server import Server
s = Server(port=10000, jvm_args=["-Xmx10g", "-DAuthHandlers=io.deephaven.auth.AnonymousAuthenticationHandler"])
s.start()
```

```
from pydeephaven.session import SharedTicket
from pydeephaven import Session
from deephaven_ipywidgets import DeephavenWidget

client_session = Session()
```

```
table_ref = client_session.time_table("PT1s").update(["X = i", "Y = X / 2"])

DeephavenWidget(table_ref)
```